### PR TITLE
Blog post editing/deleting 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,5 +73,6 @@ end
 # Use debugger
 # gem 'debugger', group: [:development, :test]
 
+gem 'capybara', group: [:test]
 gem 'webmock', group: [:test]
 gem 'mocha',   group: [:development, :test]

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -1,7 +1,7 @@
 class BlogsController < ApplicationController
 
   layout 'application'
-  before_action :set_blog, only: [:show, :edit, :update, :destroy]
+  before_action :set_blog, only: [:show, :update]
 
   # GET /blogs
   # GET /blogs.json
@@ -59,6 +59,7 @@ class BlogsController < ApplicationController
   # DELETE /blogs/1
   # DELETE /blogs/1.json
   def destroy
+    @blog = current_user.blogs.find params[:id]
     @blog.destroy
     respond_to do |format|
       format.html { redirect_to blogs_url, notice: 'Blog was successfully destroyed.' }

--- a/app/views/blogs/_form.html.erb
+++ b/app/views/blogs/_form.html.erb
@@ -21,7 +21,7 @@
     <%= f.text_area :message %>
   </div>
   <div class="actions">
-    <%= f.submit "Create New Post", class: "btn btn-large btn-primary" %>
+    <%= f.submit "Save", class: "btn btn-large btn-primary" %>
   </div>
 </div>
 <% end %>

--- a/spec/features/editing_and_deleting_blog_post_spec.rb
+++ b/spec/features/editing_and_deleting_blog_post_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+describe 'blog post authorization' do 
+  before do 
+    @user_1 = User.create(name: 'name_1', email: 'test_1@example.com', password: 'password', password_confirmation: 'password', bio: 'short bio')
+    @user_2 = User.create(name: 'name_2', email: 'test_2@example.com', password: 'password2', password_confirmation: 'password2', bio: 'slightly longer bio')
+    @blog = @user_2.blogs.create(title: 'test title', message: 'test message')
+  end 
+  
+  def login(user)
+    visit signin_path
+    
+    fill_in 'session[email]', with: user.email
+    fill_in 'session[password]', with: user.password
+    click_button 'Sign in'
+  end 
+  
+  context "links to edit and delete a blog post" do
+    it "are hidden if the user is not the author" do 
+      login(@user_1)
+      visit blog_path(@blog)
+      
+      expect(page).to have_content(@blog.title)
+      expect(page).to have_content(@blog.message)
+      expect(page).to have_content("by #{@user_2.name}")
+      expect(page).to_not have_content("edit")
+      expect(page).to_not have_content("delete")
+    end
+    
+    it "are exposed if the user is the author" do     
+      login(@user_2)
+      visit blog_path(@blog)
+
+      expect(page).to have_content('test title')
+      expect(page).to have_content('test message')
+      expect(page).to have_content("by #{@user_2.name}")
+      expect(page).to have_content("edit")
+      expect(page).to have_content("delete")
+    end 
+  end
+  
+  context 'actually editing a blog post' do 
+    it 'can be done by the author' do 
+      login(@user_2)
+      visit blog_path(@blog)
+      click_link 'edit'
+      
+      fill_in 'blog[title]', with: 'updated title'
+      fill_in 'blog[message]', with: 'updated message'
+      click_button 'Save'
+
+      expect(current_path).to eq(blog_path(@blog))
+      expect(page).to have_content('Blog was successfully updated.')
+      expect(page).to have_content('updated title')
+      expect(page).to have_content('updated message')
+    end 
+  end 
+  
+  context 'actually deleting a blog post' do 
+    it 'can be done by the author' do 
+      login(@user_2)
+      visit blog_path(@blog)
+      click_link 'delete'
+      
+      expect(current_path).to eq(blogs_path)
+      expect(Blog.where(id: @blog.id)).to be_empty
+    end 
+  end 
+end 
+
+
+
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require 'spec_helper'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
+require 'capybara/rails'
 require 'webmock/rspec'
 
 WebMock.disable_net_connect!(allow: 'api.meetup.com')


### PR DESCRIPTION
This PR: 
- Adds Capybara; 
- Renames the 'Create New Post' button to 'Save' on the form shared by blogs/new + edit; 
- Limits the blog post deletion to the current_user's posts explicitly; 
- Adds specs for editing/deleting a blog post by the author and non-author. 